### PR TITLE
Common methods for File and Folder moved to Entity

### DIFF
--- a/config/appium.txt
+++ b/config/appium.txt
@@ -1,5 +1,5 @@
 [caps]
-appActivity = "com.onlyoffice.documents.ui.activities.login.SplashActivity"
+appActivity = "app.editors.manager.ui.activities.login.SplashActivity"
 appPackage = "com.onlyoffice.documents"
 autoGrantPermissions = true
 automationName = "UiAutomator2"

--- a/framework/helpers/file_manager/copy_move.rb
+++ b/framework/helpers/file_manager/copy_move.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module FileManager
+  # Class for navigating during copy or move operations
+  class CopyMove
+    def self.make(path:, duplicate: 'copy')
+      duplicate_id = duplicate_mode_to_id duplicate
+      Navigation.operations_frame_go to: path
+      click id: ID::OPERATIONS_CONFIRM
+      sleep 2
+
+      return unless elements(id: duplicate_id).count.positive?
+
+      click id: duplicate_id
+      click id: ID::OPERATIONS_DUPLICATE_CONFIRM
+    end
+
+    def self.duplicate_mode_to_id(mode)
+      return ID::OPERATIONS_DUPLICATE_COPY if mode == 'copy'
+      return ID::OPERATIONS_DUPLICATE_OVERWRITE if mode == 'overwrite'
+      return ID::OPERATIONS_DUPLICATE_SKIP if mode == 'skip'
+    end
+  end
+end

--- a/framework/helpers/file_manager/entity.rb
+++ b/framework/helpers/file_manager/entity.rb
@@ -20,23 +20,42 @@ module FileManager
     end
 
     def share
-      raise NotImplementedError
+      # TODO
     end
 
-    def copy
-      raise NotImplementedError
+    def copy(to:)
+      open_context unless @context
+      click id: ID::CONTEXT_COPY
+      CopyMove path: to
+      @context = false
+
+      update_element_link
     end
 
-    def move
-      raise NotImplementedError
+    def move(to:)
+      open_context unless @context
+      click id: ID::CONTEXT_MOVE
+      CopyMove path: to
+      @context = false
+
+      @path = Tools.parse_path to
+      @path[:name] = @name
+      remove_element_link
     end
 
     def delete
-      raise NotImplementedError
+      open_context unless @context
+      click id: ID::CONTEXT_DELETE
+      click id: ID::DIALOG_ACCEPT
+      @context = false
+      remove_element_link
     end
 
     def info
-      raise NotImplementedError
+      open_context unless @context
+      file_info = element(id: ID::CONTEXT_INFO).text
+      close_context if @context
+      file_info
     end
 
     def open_context
@@ -45,6 +64,14 @@ module FileManager
 
     def close_context
       raise NotImplementedError
+    end
+
+    def update_element_link
+      raise NotImplementedError
+    end
+
+    def remove_element_link
+      @root_element = nil
     end
   end
 end

--- a/framework/helpers/file_manager/file.rb
+++ b/framework/helpers/file_manager/file.rb
@@ -18,13 +18,13 @@ module FileManager
       end
 
       close_editor
-      @root_element = Search.find_file_on_page @name
+      update_element_link
     end
 
     def init
       Navigation.go to: @path[:string]
       @extension = Tools.extension @name
-      @root_element = Search.find_file_on_page @name
+      update_element_link
     end
 
     def rename(name)
@@ -36,58 +36,7 @@ module FileManager
       @path[:name] = name
       @context = false
 
-      @root_element = Search.find_file_on_page @name
-    end
-
-    def share
-      # TODO
-    end
-
-    def copy(to:)
-      open_context unless @context
-      click id: ID::CONTEXT_COPY
-      Navigation.operations_frame_go to: to
-      click id: ID::OPERATIONS_CONFIRM
-      sleep 2
-      if elements(id: ID::OPERATIONS_DUPLICATE_COPY).count.positive?
-        click id: ID::OPERATIONS_DUPLICATE_COPY
-        click id: ID::OPERATIONS_DUPLICATE_CONFIRM
-      end
-      @context = false
-
-      @root_element = Search.find_file_on_page @name
-    end
-
-    def move(to:)
-      open_context unless @context
-      click id: ID::CONTEXT_MOVE
-      Navigation.operations_frame_go to: to
-      click id: ID::OPERATIONS_CONFIRM
-      sleep 2
-      if elements(id: ID::OPERATIONS_DUPLICATE_COPY).count.positive?
-        click id: ID::OPERATIONS_DUPLICATE_COPY
-        click id: ID::OPERATIONS_DUPLICATE_CONFIRM
-      end
-      @context = false
-
-      @path = Tools.parse_path to
-      @path[:name] = @name
-      @root_element = nil
-    end
-
-    def delete
-      open_context unless @context
-      click id: ID::CONTEXT_DELETE
-      click id: ID::DIALOG_ACCEPT
-      @context = false
-      @root_element = nil
-    end
-
-    def info
-      open_context unless @context
-      file_info = element(id: ID::CONTEXT_INFO).text
-      close_context if @context
-      file_info
+      update_element_link
     end
 
     def open_context
@@ -119,6 +68,14 @@ module FileManager
 
     def close_editor
       hardback pause: 2
+    end
+
+    def update_element_link
+      @root_element = Search.find_file_on_page @name
+    end
+
+    def remove_element_link
+      @root_element = nil
     end
   end
 end

--- a/framework/helpers/file_manager/folder.rb
+++ b/framework/helpers/file_manager/folder.rb
@@ -7,12 +7,12 @@ module FileManager
       Navigation.go to: @path[:string]
       Create.folder @name
 
-      @root_element = Search.find_folder_on_page @name
+      update_element_link
     end
 
     def init
       Navigation.go to: @path[:string]
-      @root_element = Search.find_folder_on_page @name
+      update_element_link
     end
 
     def rename(name)
@@ -24,58 +24,27 @@ module FileManager
       @path[:name] = name
       @context = false
 
-      @root_element = Search.find_folder_on_page @name
-    end
-
-    def share
-      # TODO
+      update_element_link
     end
 
     def copy(to:)
       open_context unless @context
       click id: ID::CONTEXT_COPY
-      Navigation.operations_frame_go to: to
-      click id: ID::OPERATIONS_CONFIRM
-      sleep 2
-      if elements(id: ID::OPERATIONS_DUPLICATE_COPY).count.positive?
-        click id: ID::OPERATIONS_DUPLICATE_COPY
-        click id: ID::OPERATIONS_DUPLICATE_CONFIRM
-      end
+      CopyMove path: to
       @context = false
 
-      @root_element = Search.find_folder_on_page @name
+      update_element_link
     end
 
     def move(to:)
       open_context unless @context
       click id: ID::CONTEXT_MOVE
-      Navigation.operations_frame_go to: to
-      click id: ID::OPERATIONS_CONFIRM
-      sleep 2
-      if elements(id: ID::OPERATIONS_DUPLICATE_COPY).count.positive?
-        click id: ID::OPERATIONS_DUPLICATE_COPY
-        click id: ID::OPERATIONS_DUPLICATE_CONFIRM
-      end
+      CopyMove path: to
       @context = false
 
       @path = Tools.parse_path to
       @path[:name] = @name
-      @root_element = nil
-    end
-
-    def delete
-      open_context unless @context
-      click id: ID::CONTEXT_DELETE
-      click id: ID::DIALOG_ACCEPT
-      @context = false
-      @root_element = nil
-    end
-
-    def info
-      open_context unless @context
-      info = element(id: ID::CONTEXT_INFO).text
-      close_context if @context
-      info
+      remove_element_link
     end
 
     def open_context
@@ -87,6 +56,10 @@ module FileManager
     def close_context
       hardback
       @context = false
+    end
+
+    def update_element_link
+      @root_element = Search.find_folder_on_page @name
     end
   end
 end


### PR DESCRIPTION
- Methods with common implementation in `FileManager::File` and `FileManager::Folder` moved to parent class `FileManager::Entity`
- Changed default appActivity
- Copy and Move operations refactoring