### PR TITLE
Personal/ Enterprise login using Google/ Facebook

### DIFF
--- a/framework/modules/cloud/unauthorized/onlyoffice/enterprise/onlyoffice_enterprise_login.rb
+++ b/framework/modules/cloud/unauthorized/onlyoffice/enterprise/onlyoffice_enterprise_login.rb
@@ -14,7 +14,7 @@ class OnlyofficeEnterpriseLogin < BasePageObject
   button 'facebook', id: 'login_social_facebook_button'
   textfield 'fb_login', xpath: "//android.widget.EditText[@index='0']"
   textfield 'fb_pass', xpath: "//android.widget.EditText[@index='1']"
-  button 'log_in', xpath: "//android.widget.Button[@index='0']" # index = 0 for phone
+  button 'fb_log_in', xpath: '//android.widget.Button'
   button 'continue', xpath: "//android.widget.Button[@index='0']"
 
   button 'google', id: 'login_social_google_button'

--- a/framework/modules/cloud/unauthorized/onlyoffice/enterprise/onlyoffice_enterprise_login.rb
+++ b/framework/modules/cloud/unauthorized/onlyoffice/enterprise/onlyoffice_enterprise_login.rb
@@ -12,7 +12,13 @@ class OnlyofficeEnterpriseLogin < BasePageObject
   button 'toggle_password', id: 'text_input_password_toggle'
   button 'sign_in', id: 'login_enterprise_signin_button'
   button 'facebook', id: 'login_social_facebook_button'
+  textfield 'fb_login', xpath: "//android.widget.EditText[@index='0']"
+  textfield 'fb_pass', xpath: "//android.widget.EditText[@index='1']"
+  button 'log_in', xpath: "//android.widget.Button[@index='0']" # index = 0 for phone
+  button 'continue', xpath: "//android.widget.Button[@index='0']"
+
   button 'google', id: 'login_social_google_button'
+  button 'google_account', xpath: "//android.widget.LinearLayout[@index='0']"
   button 'forgot_password', id: 'login_enterprise_forgot_pwd_button'
 
   def self.perform(portal_address, email, password)

--- a/framework/modules/cloud/unauthorized/onlyoffice/personal/onlyoffice_personal_login.rb
+++ b/framework/modules/cloud/unauthorized/onlyoffice/personal/onlyoffice_personal_login.rb
@@ -8,7 +8,7 @@ class OnlyofficePersonalLogin < BasePageObject
   button 'facebook', id: 'login_social_facebook_button'
   textfield 'fb_login', xpath: "//android.widget.EditText[@index='0']"
   textfield 'fb_pass', xpath: "//android.widget.EditText[@index='1']"
-  button 'log_in', xpath: "//android.widget.Button[@index='0']" # index = 0 for phone
+  button 'fb_log_in', xpath: '//android.widget.Button'
   button 'continue', xpath: "//android.widget.Button[@index='0']"
 
   button 'google', id: 'login_social_google_button'

--- a/framework/modules/cloud/unauthorized/onlyoffice/personal/onlyoffice_personal_login.rb
+++ b/framework/modules/cloud/unauthorized/onlyoffice/personal/onlyoffice_personal_login.rb
@@ -6,7 +6,14 @@ class OnlyofficePersonalLogin < BasePageObject
   textfield 'password', id: 'login_personal_portal_password_edit'
   button 'sign_in', id: 'login_personal_signin_button'
   button 'facebook', id: 'login_social_facebook_button'
+  textfield 'fb_login', xpath: "//android.widget.EditText[@index='0']"
+  textfield 'fb_pass', xpath: "//android.widget.EditText[@index='1']"
+  button 'log_in', xpath: "//android.widget.Button[@index='0']" # index = 0 for phone
+  button 'continue', xpath: "//android.widget.Button[@index='0']"
+
   button 'google', id: 'login_social_google_button'
+  button 'google_account', xpath: "//android.widget.LinearLayout[@index='0']"
+
   text 'description', id: 'login_personal_info_text'
   button 'create_portal', id: 'login_personal_signup_button'
 

--- a/spec/manager/login/login_enterprise_spec.rb
+++ b/spec/manager/login/login_enterprise_spec.rb
@@ -29,3 +29,57 @@ login_data[:enterprise].each do |portal|
     end
   end
 end
+
+login_data[:google].each do |portal|
+  describe "Login through Google to #{portal[:portal]}", :login, :enterprise, :smoke do
+    before :all do
+      Onboarding.skip_button_click
+      CloudList.get_started_button_click
+    end
+
+    it 'Input portal address' do
+      OnlyofficeEnterpriseLogin.portal_address_textfield_fill portal[:portal]
+      OnlyofficeEnterpriseLogin.next_button_click
+    end
+
+    it 'Tap Google account' do
+      OnlyofficeEnterpriseLogin.google_button_click
+      sleep 2
+      OnlyofficeEnterpriseLogin.google_account_button_click
+    end
+
+    it 'Check the portal address after login ' do
+      expected_portal = CloudTopToolBar.account_sub_title_text_value
+      expect(expected_portal).to eq(portal[:portal])
+    end
+  end
+end
+
+login_data[:facebook].each do |portal|
+  describe "Login through Facebook to  #{portal[:portal]}", :login, :enterprise, :smoke do
+    before :all do
+      Onboarding.skip_button_click
+      CloudList.get_started_button_click
+    end
+
+    it 'Input portal address' do
+      OnlyofficeEnterpriseLogin.portal_address_textfield_fill portal[:portal]
+      OnlyofficeEnterpriseLogin.next_button_click
+    end
+
+    it 'Tap Facebook account' do
+      OnlyofficeEnterpriseLogin.facebook_button_click
+      sleep 2
+      OnlyofficeEnterpriseLogin.fb_login_textfield_fill portal[:login]
+      OnlyofficeEnterpriseLogin.fb_pass_textfield_fill  portal[:pass]
+      OnlyofficeEnterpriseLogin.log_in_button_click
+      sleep 2
+      OnlyofficeEnterpriseLogin.continue_button_click
+    end
+
+    it 'Check the portal address after login ' do
+      expected_portal = CloudTopToolBar.account_sub_title_text_value
+      expect(expected_portal).to eq(portal[:portal])
+    end
+  end
+end

--- a/spec/manager/login/login_enterprise_spec.rb
+++ b/spec/manager/login/login_enterprise_spec.rb
@@ -71,7 +71,7 @@ login_data[:facebook].each do |portal|
       OnlyofficeEnterpriseLogin.facebook_button_click
       sleep 2
       OnlyofficeEnterpriseLogin.fb_login_textfield_fill portal[:login]
-      OnlyofficeEnterpriseLogin.fb_pass_textfield_fill  portal[:pass]
+      OnlyofficeEnterpriseLogin.fb_pass_textfield_fill portal[:pass]
       OnlyofficeEnterpriseLogin.fb_log_in_button_click
       sleep 2
       OnlyofficeEnterpriseLogin.continue_button_click

--- a/spec/manager/login/login_enterprise_spec.rb
+++ b/spec/manager/login/login_enterprise_spec.rb
@@ -72,7 +72,7 @@ login_data[:facebook].each do |portal|
       sleep 2
       OnlyofficeEnterpriseLogin.fb_login_textfield_fill portal[:login]
       OnlyofficeEnterpriseLogin.fb_pass_textfield_fill  portal[:pass]
-      OnlyofficeEnterpriseLogin.log_in_button_click
+      OnlyofficeEnterpriseLogin.fb_log_in_button_click
       sleep 2
       OnlyofficeEnterpriseLogin.continue_button_click
     end

--- a/spec/manager/login/login_personal_spec.rb
+++ b/spec/manager/login/login_personal_spec.rb
@@ -68,7 +68,7 @@ login_data[:facebook].each do |portal|
       OnlyofficePersonalLogin.facebook_button_click
       OnlyofficePersonalLogin.fb_login_textfield_fill portal[:login]
       OnlyofficePersonalLogin.fb_pass_textfield_fill  portal[:pass]
-      OnlyofficePersonalLogin.log_in_button_click
+      OnlyofficePersonalLogin.fb_log_in_button_click
       sleep 2
       OnlyofficePersonalLogin.continue_button_click
     end

--- a/spec/manager/login/login_personal_spec.rb
+++ b/spec/manager/login/login_personal_spec.rb
@@ -28,3 +28,54 @@ login_data[:personal].each do |portal|
     end
   end
 end
+
+login_data[:google].each do |portal|
+  describe "Login through Google to personal #{portal[:login]}", :login, :personal, :smoke do
+    before :all do
+      Onboarding.skip_button_click
+      CloudList.get_started_button_click
+    end
+
+    it('Choice Personal portal type') do
+      PortalTypeSwitcher.personal_button_click
+    end
+
+    it 'Tap Google account' do
+      OnlyofficePersonalLogin.google_button_click
+      sleep 2
+      OnlyofficePersonalLogin.google_account_button_click
+    end
+
+    it 'Check the portal address after login ' do
+      expected_portal = CloudTopToolBar.account_sub_title_text_value
+      expect(expected_portal).to eq('personal.onlyoffice.com')
+    end
+  end
+end
+
+login_data[:facebook].each do |portal|
+  describe "Login through Facebook to personal #{portal[:login]}", :login, :personal, :smoke do
+    before :all do
+      Onboarding.skip_button_click
+      CloudList.get_started_button_click
+    end
+
+    it('Choice Personal portal type') do
+      PortalTypeSwitcher.personal_button_click
+    end
+
+    it 'Tap Facebook account' do
+      OnlyofficePersonalLogin.facebook_button_click
+      OnlyofficePersonalLogin.fb_login_textfield_fill portal[:login]
+      OnlyofficePersonalLogin.fb_pass_textfield_fill  portal[:pass]
+      OnlyofficePersonalLogin.log_in_button_click
+      sleep 2
+      OnlyofficePersonalLogin.continue_button_click
+    end
+
+    it 'Check the portal address after login ' do
+      expected_portal = CloudTopToolBar.account_sub_title_text_value
+      expect(expected_portal).to eq('personal.onlyoffice.com')
+    end
+  end
+end


### PR DESCRIPTION
Specs for login through social networks. 
`xpath: "//android.widget.Button[@index='0']"` only work for smartphones.
Buttons and text fields are added to class `OnlyofficePersonalLogin` and `OnlyofficeEnterpriseLogin`